### PR TITLE
Add Gmail search URL to followup reminder

### DIFF
--- a/components/core/src/agents/job-extractor-agent.ts
+++ b/components/core/src/agents/job-extractor-agent.ts
@@ -1418,7 +1418,8 @@ Outreach activities:
         priority: reminderPriority || config.default_priority,
         tags: commonTags,
         dueDate: threeDaysFromToday,
-        dueTime: '14:00' // Early afternoon reminder
+        dueTime: '14:00', // Early afternoon reminder
+        url: `https://mail.google.com/mail/u/0/#search/in%3Asent+from%3Ame+subject%3A${encodeURIComponent(jobData.company || 'Unknown Company')}`
       };
 
       // Create all reminders as separate top-level reminders


### PR DESCRIPTION
## Summary
Adds a Gmail search URL to the followup reminder task that filters sent emails by company name.

## Changes
- Added `url` field to the `followUpReminder` object in `components/core/src/agents/job-extractor-agent.ts`
- The URL format is: `https://mail.google.com/mail/u/0/#search/in%3Asent+from%3Ame+subject%3ACOMPANY`
- The COMPANY placeholder is dynamically replaced with the actual company name and properly URL-encoded

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)